### PR TITLE
Patching values.yaml to use JupyterHub 5.3.0

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -62,6 +62,7 @@ prePuller:
 
 scheduling:
   userScheduler:
+    enabled: false
     containerSecurityContext:
       <<: *security_context
       runAsUser: # let openshift set the value

--- a/values.yaml
+++ b/values.yaml
@@ -42,6 +42,7 @@ singleuser:
   fsGid:
   cloudMetadata:
     blockWithIptables: false
+  # fix storage problem when using jupyterhub 5.3.0
   storage:
     type: dynamic
     capacity: 1Gi
@@ -71,6 +72,7 @@ prePuller:
 
 scheduling:
   userScheduler:
+    # quick fix for openshift auth problem: "cannot get resource..."
     enabled: false
     containerSecurityContext:
       <<: *security_context

--- a/values.yaml
+++ b/values.yaml
@@ -42,6 +42,15 @@ singleuser:
   fsGid:
   cloudMetadata:
     blockWithIptables: false
+  storage:
+    type: dynamic
+    capacity: 1Gi
+    homeMountPath: /home/jovyan
+    dynamic:
+      storageClass: ocs-storagecluster-ceph-rbd
+      pvcNameTemplate: claim-{username}-{servername}
+      volumeNameTemplate: claim-{username}-{servername}
+
 
 prePuller:
   containerSecurityContext:


### PR DESCRIPTION
Let me start by thanking you very much for this software!

I needed to use a more recent version of JupyterHub (5.3.0) with your package. To do this I had to add a modified `storage` for the home-directory.

Furthermore I needed to disable the `userSchedule` because of restrictions in our universities OpenShift configuration.
